### PR TITLE
create ingestion lambda terraform and dummy lambda_ingest.py

### DIFF
--- a/src/lambda_ingest.py
+++ b/src/lambda_ingest.py
@@ -1,0 +1,3 @@
+def lambda_handler(event,context):
+    print('your lambdas have been handled')
+    return {"statusCode": 200, "body": "placeholder lambdaa executed successfully"}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,71 @@
+#ingestion lambda iam role, permissions. some parts reusable for other lambdas: 
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_iam_role" "lambda_role" {
+  name_prefix        = "role-ingestion-lambdas-"
+  assume_role_policy = <<EOF
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "sts:AssumeRole"
+                ],
+                "Principal": {
+                    "Service": [
+                        "lambda.amazonaws.com"
+                    ]
+                }
+            }
+        ]
+    }
+    EOF
+}
+
+##maybe make resources more dynamic in case we create a new ingestion bucket:
+data "aws_iam_policy_document" "s3_document" {
+  statement {
+    actions = ["s3:PutObject"]
+    resources = [
+      "arn:aws:s3:::s3-totes-sys-ingestion-bucket-20250224150910335400000001/*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "cw_document" {
+  statement {
+    actions = ["logs:CreateLogGroup"]
+    resources = [
+      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+    ]
+  }
+  statement {
+    actions = ["logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = [
+      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:*:*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "s3_policy" {
+  name        = "s3-policy-ingestion-lambda"
+  description = "policy for writing to the S3 bucket"
+  policy      = data.aws_iam_policy_document.s3_document.json
+}
+
+resource "aws_iam_policy" "cw_policy" {
+  name        = "cw-policy-ingestion-lambda"
+  policy      = data.aws_iam_policy_document.cw_document.json
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_s3_policy_attachment" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = aws_iam_policy.s3_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_cw_policy_attachment" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = aws_iam_policy.cw_policy.arn
+}

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -1,0 +1,15 @@
+data "archive_file" "ingestion_lambda" {
+  type        = "zip"
+  output_path = "${path.module}/../packages/ingestion/function.zip"
+  source_file = "${path.module}/../src/lambda_ingest.py"
+}
+
+resource "aws_lambda_function" "ingestion_handler" {
+  function_name    = "ingestion_handler"
+  filename = data.archive_file.ingestion_lambda.output_path
+  source_code_hash = data.archive_file.ingestion_lambda.output_base64sha256
+  role             = aws_iam_role.lambda_role.arn
+  handler          = "lambda_ingest.lambda_handler"
+  runtime          = "python3.12"
+  timeout          = 30
+}


### PR DESCRIPTION
The dummy lambda_ingest can be replaced with Achint's real code and the terraform re-run to zip the correct code. Tested via console
![Screenshot 2025-02-24 174912](https://github.com/user-attachments/assets/910d7336-4f4d-4b6f-a322-36edd488e433)
