### PR TITLE
terraform for ingestion lambda (branch = fiona-ingestion-tf)

### DIFF
--- a/src/lambda_ingest.py
+++ b/src/lambda_ingest.py
@@ -1,0 +1,3 @@
+def lambda_handler(event,context):
+    print('your lambdas have been handled')
+    return {"statusCode": 200, "body": "placeholder lambdaa executed successfully"}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,71 @@
+#ingestion lambda iam role, permissions. some parts reusable for other lambdas: 
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_iam_role" "lambda_role" {
+  name_prefix        = "role-ingestion-lambdas-"
+  assume_role_policy = <<EOF
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "sts:AssumeRole"
+                ],
+                "Principal": {
+                    "Service": [
+                        "lambda.amazonaws.com"
+                    ]
+                }
+            }
+        ]
+    }
+    EOF
+}
+
+##maybe make resources more dynamic in case we create a new ingestion bucket:
+data "aws_iam_policy_document" "s3_document" {
+  statement {
+    actions = ["s3:PutObject"]
+    resources = [
+      "arn:aws:s3:::s3-totes-sys-ingestion-bucket-20250224150910335400000001/*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "cw_document" {
+  statement {
+    actions = ["logs:CreateLogGroup"]
+    resources = [
+      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+    ]
+  }
+  statement {
+    actions = ["logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = [
+      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:*:*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "s3_policy" {
+  name        = "s3-policy-ingestion-lambda"
+  description = "policy for writing to the S3 bucket"
+  policy      = data.aws_iam_policy_document.s3_document.json
+}
+
+resource "aws_iam_policy" "cw_policy" {
+  name        = "cw-policy-ingestion-lambda"
+  policy      = data.aws_iam_policy_document.cw_document.json
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_s3_policy_attachment" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = aws_iam_policy.s3_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_cw_policy_attachment" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = aws_iam_policy.cw_policy.arn
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -24,12 +24,11 @@ resource "aws_iam_role" "lambda_role" {
     EOF
 }
 
-##maybe make resources more dynamic in case we create a new ingestion bucket:
 data "aws_iam_policy_document" "s3_document" {
   statement {
     actions = ["s3:PutObject"]
     resources = [
-      "arn:aws:s3:::s3-totes-sys-ingestion-bucket-20250224150910335400000001/*",
+      "${aws_s3_bucket.s3_ingestion_bucket.arn}/*"
     ]
   }
 }

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -1,0 +1,15 @@
+data "archive_file" "ingestion_lambda" {
+  type        = "zip"
+  output_path = "${path.module}/../packages/ingestion/function.zip"
+  source_file = "${path.module}/../src/lambda_ingest.py"
+}
+
+resource "aws_lambda_function" "ingestion_handler" {
+  function_name    = "ingestion_handler"
+  filename = data.archive_file.ingestion_lambda.output_path
+  source_code_hash = data.archive_file.ingestion_lambda.output_base64sha256
+  role             = aws_iam_role.lambda_role.arn
+  handler          = "lambda_ingest.lambda_handler"
+  runtime          = "python3.12"
+  timeout          = 30
+}

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -4,12 +4,21 @@ data "archive_file" "ingestion_lambda" {
   source_file = "${path.module}/../src/lambda_ingest.py"
 }
 
+resource "aws_s3_object" "lambda_code" {
+bucket = aws_s3_bucket.code_bucket.bucket
+  key    = "ingestion/function.zip"
+  source = data.archive_file.ingestion_lambda.output_path
+  etag   = filemd5(data.archive_file.ingestion_lambda.output_path)
+}
+
 resource "aws_lambda_function" "ingestion_handler" {
   function_name    = "ingestion_handler"
-  filename = data.archive_file.ingestion_lambda.output_path
+  s3_bucket        = aws_s3_bucket.code_bucket.bucket
+  s3_key           = aws_s3_object.lambda_code.key
   source_code_hash = data.archive_file.ingestion_lambda.output_base64sha256
   role             = aws_iam_role.lambda_role.arn
   handler          = "lambda_ingest.lambda_handler"
   runtime          = "python3.12"
   timeout          = 30
 }
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -24,3 +24,4 @@ provider "aws" {
     }
   }
 }
+

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,3 +1,8 @@
 resource "aws_s3_bucket" "s3_ingestion_bucket" {
     bucket_prefix = "${var.S3_BUCKET_PREFIX}-"
 }
+
+resource "aws_s3_bucket" "code_bucket" {
+  bucket_prefix = "totesys-code-bucket-"
+}
+


### PR DESCRIPTION
this is the terraform for the ingestion lambda. iam permissions to write to s3, log events to cloudwatch. 
- also added code bucket to s3.tf for the lambda code. 
- zipped dummy code for the lambda (from lambda_ingest.py), to be replaced by Achint's ingestion code.
- tested dummy code via console, image attached.
![Screenshot 2025-02-25 100219](https://github.com/user-attachments/assets/9a8d67ee-8eca-4765-9b5b-b683f98fc87a)

