### PR TITLE
Orchastration state machine

### DIFF
--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudwatch_log_metric_filter" "error_filter" {
   name           = "ErrorFilter"
-  log_group_name = "/aws/vendedlogs/states/pipeline" #update for the actual log group name
+  log_group_name = "/aws/state-machine/pipeline" #update for the actual log group name
   pattern        = "ExecutionFailed" # Adjust pattern to match error logs 
 
   metric_transformation {
@@ -9,6 +9,7 @@ resource "aws_cloudwatch_log_metric_filter" "error_filter" {
     value         = "1"
     default_value = 0
   }
+  depends_on = [ aws_cloudwatch_log_group.state_machine_logs ]
 }
 
 resource "aws_cloudwatch_metric_alarm" "error_alarm_with_role" {
@@ -22,4 +23,10 @@ resource "aws_cloudwatch_metric_alarm" "error_alarm_with_role" {
   threshold           = "1"
   alarm_actions       = [aws_sns_topic.error_notifications.arn]
   depends_on          = [aws_cloudwatch_log_metric_filter.error_filter, aws_sns_topic_subscription.email_subscription, aws_iam_role_policy_attachment.cloudwatch_alarm_sns_policy_attachment]
+}
+
+resource "aws_cloudwatch_log_group" "state_machine_logs" {
+  name = "/aws/state-machine/pipeline"
+  retention_in_days = 30
+  
 }

--- a/terraform/eventbridge.tf
+++ b/terraform/eventbridge.tf
@@ -7,7 +7,7 @@ resource "aws_scheduler_schedule" "pipeline_scheduler" {
       mode = "OFF"
     }
     target {
-      arn = aws_lambda_function.ingestion_handler.arn
+      arn = aws_sfn_state_machine.pipeline-machine.arn
       role_arn = aws_iam_role.scheduler_role.arn
       retry_policy {
         maximum_event_age_in_seconds = 600 #decide time frame each run will be valid

--- a/terraform/eventbridge.tf
+++ b/terraform/eventbridge.tf
@@ -7,7 +7,7 @@ resource "aws_scheduler_schedule" "pipeline_scheduler" {
       mode = "OFF"
     }
     target {
-      arn = aws_sfn_state_machine.pipeline-machine.arn
+      arn = aws_sfn_state_machine.pipeline_machine.arn
       role_arn = aws_iam_role.scheduler_role.arn
       retry_policy {
         maximum_event_age_in_seconds = 600 #decide time frame each run will be valid

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -145,3 +145,50 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_alarm_sns_policy_attachmen
   role       = aws_iam_role.cloudwatch_alarm_sns_role.name
   policy_arn = aws_iam_policy.cloudwatch_alarm_sns_policy.arn
 }
+
+resource "aws_iam_role" "state_machine_role" {
+  name = "state-machine-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "states.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "state_machine_cloudwatch_logs_policy" {
+  name        = "state-machine-cloudwatch-logs-policy"
+  description = "Policy to allow state machine to write logs to CloudWatch Logs"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          # "logs:CreateLogStream",
+          # "logs:PutLogEvents"
+          "*"
+        ],
+        Resource = [
+          # "${aws_cloudwatch_log_group.state_machine_logs.arn}:*",
+          # aws_cloudwatch_log_group.state_machine_logs.arn      
+          "*"   
+        ]
+      }
+    ]
+  })
+
+}
+
+resource "aws_iam_role_policy_attachment" "state_machine_logs_attachment" {
+  role       = aws_iam_role.state_machine_role.name
+  policy_arn = aws_iam_policy.state_machine_cloudwatch_logs_policy.arn
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -69,7 +69,7 @@ resource "aws_iam_role_policy_attachment" "lambda_cw_policy_attachment" {
   policy_arn = aws_iam_policy.cw_policy.arn
 }
 
-# IAM Role for EventBridge Scheduler to invoke Lambda
+# IAM Role for EventBridge Scheduler to invoke state machine
 resource "aws_iam_role" "scheduler_role" {
   name = "eventbridge-scheduler-role"
   assume_role_policy = jsonencode({
@@ -86,22 +86,22 @@ resource "aws_iam_role" "scheduler_role" {
   })
 }
 
-resource "aws_iam_policy_attachment" "scheduler_lambda_policy_attachment" {
-  name       = "scheduler-lambda-policy-attachment"
+resource "aws_iam_policy_attachment" "scheduler_state_machine_policy_attachment" {
+  name       = "scheduler-state-machine-policy-attachment"
   roles      = [aws_iam_role.scheduler_role.name]
-  policy_arn = aws_iam_policy.scheduler_lambda_policy.arn
+  policy_arn = aws_iam_policy.scheduler_state_machine_policy.arn
 }
 
-resource "aws_iam_policy" "scheduler_lambda_policy" {
-  name        = "scheduler-lambda-policy"
-  description = "Policy to allow EventBridge Scheduler to invoke Lambda"
+resource "aws_iam_policy" "scheduler_state_machine_policy" {
+  name        = "scheduler-state-machine-policy"
+  description = "Policy to allow EventBridge Scheduler to invoke state machine"
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
         Effect   = "Allow"
-        Action   = "lambda:InvokeFunction"
-        Resource = aws_lambda_function.ingestion_handler.arn
+        Action   = [ "states:StartExecution" ],
+        Resource = aws_sfn_state_machine.pipeline_machine.arn
       },
     ]
   })

--- a/terraform/statemachine.tf
+++ b/terraform/statemachine.tf
@@ -82,7 +82,7 @@ resource "aws_sfn_state_machine" "pipeline_machine" {
 
   logging_configuration {
     level = "ALL"
-    # include_execution_data = true
+    include_execution_data = true
     log_destination = "${aws_cloudwatch_log_group.state_machine_logs.arn}:*"
   }
   depends_on = [ aws_cloudwatch_log_group.state_machine_logs, aws_iam_role_policy_attachment.state_machine_logs_attachment ]

--- a/terraform/statemachine.tf
+++ b/terraform/statemachine.tf
@@ -1,0 +1,89 @@
+resource "aws_sfn_state_machine" "pipeline-machine" {
+  name     = "pipeline-state-machine"
+  role_arn = aws_iam_role.state_machine_role.arn
+
+  definition = jsonencode({
+  "StartAt": "Ingest Lambda",
+  "States": {
+    "Ingest Lambda": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "OutputPath": "$.Payload",
+      "Parameters": {
+        "Payload": {
+          "timestamp": "sampleValue1",
+          "uuid": "uniquenumber"
+        },
+        "FunctionName": "arn:aws:lambda:eu-west-2:180294204691:function:ingestion_handler:$LATEST"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            ""
+          ],
+          "MaxAttempts": 3,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL",
+          "IntervalSeconds": 60
+        }
+      ],
+      "Next": "Transform Lambda"
+    },
+    "Transform Lambda": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "OutputPath": "$.Payload",
+      "Parameters": {
+        "Payload": {
+          "timestamp": "sampleValue1",
+          "uuid": "uniquenumber"
+        },
+        "FunctionName": "arn:aws:lambda:eu-west-2:180294204691:function:ingestion_handler:$LATEST" #update me
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            ""
+          ],
+          "MaxAttempts": 3,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL",
+          "IntervalSeconds": 60
+        }
+      ],
+      "Next": "Load Lambda"
+    },
+    "Load Lambda": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "OutputPath": "$.Payload",
+      "Parameters": {
+        "Payload": {
+          "timestamp": "sampleValue1",
+          "uuid": "uniquenumber"
+        },
+        "FunctionName": "arn:aws:lambda:eu-west-2:180294204691:function:ingestion_handler:$LATEST" #update me
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            ""
+          ],
+          "MaxAttempts": 3,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL",
+          "IntervalSeconds": 60
+        }
+      ],
+      "End": true
+    }
+  }
+})
+
+  logging_configuration {
+    level = "ALL"
+    # include_execution_data = true
+    log_destination = "${aws_cloudwatch_log_group.state_machine_logs.arn}:*"
+  }
+  depends_on = [ aws_cloudwatch_log_group.state_machine_logs, aws_iam_role_policy_attachment.state_machine_logs_attachment ]
+}

--- a/terraform/statemachine.tf
+++ b/terraform/statemachine.tf
@@ -1,4 +1,4 @@
-resource "aws_sfn_state_machine" "pipeline-machine" {
+resource "aws_sfn_state_machine" "pipeline_machine" {
   name     = "pipeline-state-machine"
   role_arn = aws_iam_role.state_machine_role.arn
 


### PR DESCRIPTION
Added a state machine, updated cloudwatch notification and connected event bridge scheduler
Now we can run lambdas in series, retry 3 times with delay, put lambda logs to their log groups, but also track the status of the pipeline and receive an email when the whole pipeline fails, instead of getting separate notification for each failed retry
![orchs](https://github.com/user-attachments/assets/3b29b4b4-9e44-49cc-9315-5d014b9b7ef1)
